### PR TITLE
ER図とDDLのドキュメント修正

### DIFF
--- a/docs/databases/ddl.md
+++ b/docs/databases/ddl.md
@@ -1,62 +1,64 @@
-# Database Schema DDL
-
-## Overview
-
-- RDBMS: PostgreSQL
-- ID: BIGSERIAL
-- Timestamp: TIMESTAMPTZ
-- Monetary value: NUMERIC(12,2)
-- All tables use created_at, updated_at (except mapping tables where updated_at is optional)
-- Foreign key constraints and indexes are explicitly defined
+-- =========================================================
+-- Database Schema DDL (B案: subject_type/subject_id によるポリモーフィック参照)
+-- RDBMS: PostgreSQL
+-- ID: BIGSERIAL
+-- Timestamp: TIMESTAMPTZ
+-- Money: NUMERIC(12,2)
+-- =========================================================
 
 ---
 
-### 1. user_positions
+-- 1. user_positions
+
+---
 
 ```sql
 CREATE TABLE user_positions (
-    id              BIGSERIAL PRIMARY KEY,
-    name            VARCHAR(100) NOT NULL UNIQUE,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+id BIGSERIAL PRIMARY KEY,
+name VARCHAR(100) NOT NULL UNIQUE,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
 ---
 
-### 2. roles
+-- 2. roles
+
+---
 
 ```sql
 CREATE TABLE roles (
-    id              BIGSERIAL PRIMARY KEY,
-    name            VARCHAR(50) NOT NULL UNIQUE,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+id BIGSERIAL PRIMARY KEY,
+name VARCHAR(50) NOT NULL UNIQUE,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
 ---
 
-### 3. users
+-- 3. users
 
-※ role_id は users に持たず、user_roles（多対多）で付与する
+---
 
 ```sql
 CREATE TABLE users (
-    id              BIGSERIAL PRIMARY KEY,
-    name            VARCHAR(100) NOT NULL,
-    email           VARCHAR(255) NOT NULL UNIQUE,
-    password_hash   VARCHAR(255) NOT NULL,
-    position_id     BIGINT,
-    is_active       BOOLEAN NOT NULL DEFAULT TRUE,
-    last_login_at   TIMESTAMPTZ,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+id BIGSERIAL PRIMARY KEY,
+name VARCHAR(100) NOT NULL,
+email VARCHAR(255) NOT NULL UNIQUE,
+password_hash VARCHAR(255) NOT NULL,
+position_id BIGINT,
+is_active BOOLEAN NOT NULL DEFAULT TRUE,
+last_login_at TIMESTAMPTZ,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_users_position
         FOREIGN KEY (position_id)
         REFERENCES user_positions(id)
         ON DELETE SET NULL
+
 );
 
 CREATE INDEX idx_users_position_id ON users(position_id);
@@ -64,13 +66,15 @@ CREATE INDEX idx_users_position_id ON users(position_id);
 
 ---
 
-### 4. user_roles
+-- 4. user_roles
+
+---
 
 ```sql
 CREATE TABLE user_roles (
-    user_id     BIGINT NOT NULL,
-    role_id     BIGINT NOT NULL,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+user_id BIGINT NOT NULL,
+role_id BIGINT NOT NULL,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     PRIMARY KEY (user_id, role_id),
 
@@ -83,54 +87,56 @@ CREATE TABLE user_roles (
         FOREIGN KEY (role_id)
         REFERENCES roles(id)
         ON DELETE RESTRICT
+
 );
 
 CREATE INDEX idx_user_roles_role_id ON user_roles(role_id);
+
 ```
 
 ---
 
-### 5. purchasing_approval_statuses
+-- 5. purchasing_approval_statuses
 
-- code: システム識別子（例: PENDING/RETURNED/APPROVED）
-- name: 表示名（日本語でもOK）
+---
 
 ```sql
 CREATE TABLE purchasing_approval_statuses (
-    id          BIGSERIAL PRIMARY KEY,
-    code        VARCHAR(30) NOT NULL UNIQUE,
-    name        VARCHAR(50) NOT NULL,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+id BIGSERIAL PRIMARY KEY,
+code VARCHAR(30) NOT NULL UNIQUE,
+name VARCHAR(50) NOT NULL,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
 ---
 
-### 6. purchasing_approvals
+-- 6. purchasing_approvals (提出後の本申請)
 
-- current_status_id / current_event_id を追加（高速参照用スナップショット）
-- requested_at / approved_at はスナップショット（イベントから導出可能だが一覧最適化で保持）
+---
 
-※ current_event_id の FK は events 作成後に ALTER で追加する（循環参照回避）
+-- NOTE:
+-- - v1ではDRAFTは別テーブルで扱う想定（本テーブルは必須カラムNOT NULLのまま）
+-- - current_event_id は events 作成後にFKを追加（循環参照回避）
 
 ```sql
 CREATE TABLE purchasing_approvals (
-    id                  BIGSERIAL PRIMARY KEY,
-    user_id             BIGINT NOT NULL,
-    title               VARCHAR(200) NOT NULL,
-    purchase_type       VARCHAR(100) NOT NULL,
-    amount              NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
-    reason              TEXT NOT NULL,
+id BIGSERIAL PRIMARY KEY,
+user_id BIGINT NOT NULL,
+title VARCHAR(200) NOT NULL,
+purchase_type VARCHAR(100) NOT NULL,
+amount NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
+reason TEXT NOT NULL,
 
-    current_status_id   BIGINT NOT NULL,
-    current_event_id    BIGINT,
+    current_status_id BIGINT NOT NULL,
+    current_event_id  BIGINT,
 
-    requested_at        TIMESTAMPTZ,
-    approved_at         TIMESTAMPTZ,
+    requested_at      TIMESTAMPTZ,
+    approved_at       TIMESTAMPTZ,
 
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_approvals_user
         FOREIGN KEY (user_id)
@@ -141,6 +147,7 @@ CREATE TABLE purchasing_approvals (
         FOREIGN KEY (current_status_id)
         REFERENCES purchasing_approval_statuses(id)
         ON DELETE RESTRICT
+
 );
 
 CREATE INDEX idx_approvals_user_id ON purchasing_approvals(user_id);
@@ -150,28 +157,82 @@ CREATE INDEX idx_approvals_amount ON purchasing_approvals(amount);
 
 ---
 
-### 7. purchasing_approval_events
+-- 7. draft_purchasing_approvals (未提出の下書き)
 
-- action: submit/approve/return/resubmit/comment など
-- comment: 任意コメント（差し戻し理由等）
-- 最新イベント取得を意識して (purchasing_approval_id, id DESC) を推奨
+---
+
+-- NOTE:
+-- - DRAFT段階のため、入力項目はNULL許容
+-- - last_touched_at は一覧の並びやGC（掃除）で利用する想定
+-- - current_event_id は events 作成後にFKを追加（循環参照回避）
+
+```sql
+CREATE TABLE draft_purchasing_approvals (
+id BIGSERIAL PRIMARY KEY,
+user_id BIGINT NOT NULL,
+
+    title             VARCHAR(200),
+    purchase_type     VARCHAR(100),
+    amount            NUMERIC(12,2) CHECK (amount >= 0),
+    reason            TEXT,
+
+    current_status_id BIGINT NOT NULL,
+    current_event_id  BIGINT,
+
+    last_touched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_drafts_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE RESTRICT,
+
+    CONSTRAINT fk_drafts_current_status
+        FOREIGN KEY (current_status_id)
+        REFERENCES purchasing_approval_statuses(id)
+        ON DELETE RESTRICT
+
+);
+
+CREATE INDEX idx_drafts_user_id ON draft_purchasing_approvals(user_id);
+CREATE INDEX idx_drafts_current_status_id ON draft_purchasing_approvals(current_status_id);
+CREATE INDEX idx_drafts_last_touched_at ON draft_purchasing_approvals(last_touched_at);
+```
+
+---
+
+-- 8. purchasing_approval_events (ポリモーフィック参照)
+
+---
+
+-- subject_type: 'approval' | 'draft'
+-- subject_id:
+-- - subject_type='approval' -> purchasing_approvals.id
+-- - subject_type='draft' -> draft_purchasing_approvals.id
+--
+
+-- IMPORTANT:
+-- - subject_id はDBのFK制約を張れない（ポリモーフィックのため）
+-- - アプリ層で存在チェック・整合性担保を行う
 
 ```sql
 CREATE TABLE purchasing_approval_events (
-    id                      BIGSERIAL PRIMARY KEY,
-    purchasing_approval_id  BIGINT NOT NULL,
-    performed_by            BIGINT NOT NULL,
-    status_id               BIGINT NOT NULL,
-    action                  VARCHAR(30) NOT NULL,
-    comment                 TEXT,
-    event_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+id BIGSERIAL PRIMARY KEY,
 
-    CONSTRAINT fk_event_approval
-        FOREIGN KEY (purchasing_approval_id)
-        REFERENCES purchasing_approvals(id)
-        ON DELETE CASCADE,
+    subject_type  VARCHAR(30) NOT NULL,
+    subject_id    BIGINT NOT NULL,
+
+    performed_by  BIGINT NOT NULL,
+    status_id     BIGINT NOT NULL,
+
+    action        VARCHAR(30) NOT NULL,
+    comment       TEXT,
+
+    event_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_event_user
         FOREIGN KEY (performed_by)
@@ -181,21 +242,27 @@ CREATE TABLE purchasing_approval_events (
     CONSTRAINT fk_event_status
         FOREIGN KEY (status_id)
         REFERENCES purchasing_approval_statuses(id)
-        ON DELETE RESTRICT
+        ON DELETE RESTRICT,
+
+    CONSTRAINT chk_event_subject_type
+        CHECK (subject_type IN ('approval', 'draft'))
+
 );
 
-CREATE INDEX idx_events_approval_id_id_desc
-ON purchasing_approval_events(purchasing_approval_id, id DESC);
+-- 最新イベント取得（対象ごと）
+CREATE INDEX idx_events_subject_id_id_desc
+ON purchasing_approval_events(subject_type, subject_id, id DESC);
 
 CREATE INDEX idx_events_status_id ON purchasing_approval_events(status_id);
 CREATE INDEX idx_events_action ON purchasing_approval_events(action);
+CREATE INDEX idx_events_event_at ON purchasing_approval_events(event_at);
 ```
 
 ---
 
-### 8. purchasing_approvals.current_event_id FK（後付け）
+-- 9. purchasing_approvals.current_event_id FK（後付け）
 
-※ events 作成後に実行
+---
 
 ```sql
 ALTER TABLE purchasing_approvals
@@ -207,18 +274,32 @@ ON DELETE SET NULL;
 
 ---
 
-### 9. purchasing_approval_comments
+-- 10. draft_purchasing_approvals.current_event_id FK（後付け）
 
-- commented_by: コメント投稿者
+---
+
+```sql
+ALTER TABLE draft_purchasing_approvals
+ADD CONSTRAINT fk_drafts_current_event
+FOREIGN KEY (current_event_id)
+REFERENCES purchasing_approval_events(id)
+ON DELETE SET NULL;
+```
+
+---
+
+-- 11. purchasing_approval_comments
+
+---
 
 ```sql
 CREATE TABLE purchasing_approval_comments (
-    id            BIGSERIAL PRIMARY KEY,
-    event_id      BIGINT NOT NULL,
-    commented_by  BIGINT NOT NULL,
-    comment_text  TEXT NOT NULL,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+id BIGSERIAL PRIMARY KEY,
+event_id BIGINT NOT NULL,
+commented_by BIGINT NOT NULL,
+comment_text TEXT NOT NULL,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_comment_event
         FOREIGN KEY (event_id)
@@ -229,40 +310,43 @@ CREATE TABLE purchasing_approval_comments (
         FOREIGN KEY (commented_by)
         REFERENCES users(id)
         ON DELETE RESTRICT
+
 );
 
 CREATE INDEX idx_comments_event_id ON purchasing_approval_comments(event_id);
+CREATE INDEX idx_comments_created_at ON purchasing_approval_comments(created_at);
 ```
 
 ---
 
-### 10. purchasing_approval_ai_summaries
+-- 12. purchasing_approval_ai_summaries
+
+---
 
 ```sql
 CREATE TABLE purchasing_approval_ai_summaries (
-    id           BIGSERIAL PRIMARY KEY,
-    event_id     BIGINT NOT NULL,
-    summary_text TEXT NOT NULL,
-    summary_type VARCHAR(50) NOT NULL,
-    generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+id BIGSERIAL PRIMARY KEY,
+event_id BIGINT NOT NULL,
+summary_text TEXT NOT NULL,
+summary_type VARCHAR(50) NOT NULL,
+generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_summary_event
         FOREIGN KEY (event_id)
         REFERENCES purchasing_approval_events(id)
         ON DELETE CASCADE
+
 );
 
 CREATE INDEX idx_summaries_event_id ON purchasing_approval_ai_summaries(event_id);
 CREATE INDEX idx_summaries_type ON purchasing_approval_ai_summaries(summary_type);
 ```
 
----
-
-## Seed（参考）
-
-- purchasing_approval_statuses.code:
-  - PENDING, RETURNED, APPROVED（PoC最小）
-  - （必要なら DRAFT/CANCELLED/REJECTED を追加）
-- roles.name:
-  - applicant, approver, admin
+-- =========================================================
+-- Seeds (参考)
+-- =========================================================
+-- purchasing_approval_statuses.code:
+-- DRAFT, PENDING, RETURNED, APPROVED など
+-- roles.name:
+-- applicant, approver, admin

--- a/docs/diagrams/er/er.mmd
+++ b/docs/diagrams/er/er.mmd
@@ -45,8 +45,21 @@ erDiagram
         timestamp created_at
     }
 
+    PURCHASING_APPROVAL_STATUSES {
+        %% ステータスID
+        int id PK
+        %% ステータスコード（例: DRAFT/PENDING/RETURNED/APPROVED）
+        string code
+        %% ステータス名
+        string name
+        %% 作成日時
+        timestamp created_at
+        %% 更新日時
+        timestamp updated_at
+    }
+
     PURCHASING_APPROVALS {
-        %% 購買申請ID
+        %% 購買申請ID（提出後の本申請）
         int id PK
         %% 申請者ユーザーID
         int user_id FK
@@ -75,13 +88,29 @@ erDiagram
         timestamp updated_at
     }
 
-    PURCHASING_APPROVAL_STATUSES {
-        %% ステータスID
+    DRAFT_PURCHASING_APPROVALS {
+        %% 下書きID（未提出の下書き）
         int id PK
-        %% ステータスコード（例: DRAFT/PENDING）
-        string code
-        %% ステータス名
-        string name
+        %% 申請者ユーザーID
+        int user_id FK
+
+        %% 件名（下書きなのでNULL許容想定）
+        string title
+        %% 購買種別（下書きなのでNULL許容想定）
+        string purchase_type
+        %% 金額（下書きなのでNULL許容想定）
+        decimal amount
+        %% 申請理由（下書きなのでNULL許容想定）
+        text reason
+
+        %% 現在ステータスID（DRAFTを想定）
+        int current_status_id FK
+        %% 現在イベントID（最新イベント参照・最適化用）
+        int current_event_id FK
+
+        %% 最終操作日時（一覧の並び替え等に利用）
+        timestamp last_touched_at
+
         %% 作成日時
         timestamp created_at
         %% 更新日時
@@ -89,23 +118,43 @@ erDiagram
     }
 
     PURCHASING_APPROVAL_EVENTS {
-        %% 申請イベントID
+        %% イベントID
         int id PK
-        %% 購買申請ID
-        int purchasing_approval_id FK
+
+        %% ポリモーフィック参照
+        %% subject_type: approval / draft
+        string subject_type
+        %% subject_id: 対象テーブルのID
+        int subject_id
+
         %% 実行者ユーザーID
         int performed_by FK
         %% 遷移先ステータスID
         int status_id FK
 
-        %% アクション（例: submit/approve/reject/return/cancel/comment）
+        %% アクション（例: draft_created/submit/approve/return/comment）
         string action
-        %% イベントコメント（任意）
+        %% イベント付随メモ（差し戻し理由等・任意）
         text comment
 
         %% イベント発生日時（業務時刻）
         timestamp event_at
         %% 作成日時（記録時刻）
+        timestamp created_at
+        %% 更新日時
+        timestamp updated_at
+    }
+
+    PURCHASING_APPROVAL_COMMENTS {
+        %% コメントID
+        int id PK
+        %% 紐づくイベントID
+        int event_id FK
+        %% コメント投稿者ユーザーID
+        int commented_by FK
+        %% コメント本文
+        text comment_text
+        %% 作成日時
         timestamp created_at
         %% 更新日時
         timestamp updated_at
@@ -126,32 +175,23 @@ erDiagram
         timestamp created_at
     }
 
-    PURCHASING_APPROVAL_COMMENTS {
-        %% コメントID
-        int id PK
-        %% 紐づくイベントID
-        int event_id FK
-        %% コメント投稿者ユーザーID
-        int commented_by FK
-        %% コメント本文
-        text comment_text
-        %% 作成日時
-        timestamp created_at
-        %% 更新日時
-        timestamp updated_at
-    }
-
-    %% relations
+    %% relations (DB-level FKs)
     USER_POSITIONS ||--o{ USERS : "has"
-    USERS ||--o{ PURCHASING_APPROVALS : "creates"
-
     USERS ||--o{ USER_ROLES : "has"
     ROLES ||--o{ USER_ROLES : "assigned"
 
-    PURCHASING_APPROVALS ||--o{ PURCHASING_APPROVAL_EVENTS : "has"
-    PURCHASING_APPROVAL_STATUSES ||--o{ PURCHASING_APPROVAL_EVENTS : "defines"
-
-    PURCHASING_APPROVAL_EVENTS ||--o{ PURCHASING_APPROVAL_AI_SUMMARIES : "generates"
-    PURCHASING_APPROVAL_EVENTS ||--o{ PURCHASING_APPROVAL_COMMENTS : "has"
+    USERS ||--o{ PURCHASING_APPROVALS : "creates"
+    USERS ||--o{ DRAFT_PURCHASING_APPROVALS : "creates"
 
     PURCHASING_APPROVAL_STATUSES ||--o{ PURCHASING_APPROVALS : "current"
+    PURCHASING_APPROVAL_STATUSES ||--o{ DRAFT_PURCHASING_APPROVALS : "current"
+    PURCHASING_APPROVAL_STATUSES ||--o{ PURCHASING_APPROVAL_EVENTS : "defines"
+
+    USERS ||--o{ PURCHASING_APPROVAL_EVENTS : "performs"
+
+    PURCHASING_APPROVAL_EVENTS ||--o{ PURCHASING_APPROVAL_COMMENTS : "has"
+    PURCHASING_APPROVAL_EVENTS ||--o{ PURCHASING_APPROVAL_AI_SUMMARIES : "generates"
+
+    %% NOTE:
+    %% PURCHASING_APPROVAL_EVENTS.subject_type/subject_id はポリモーフィック参照のため
+    %% DBのFK線では表現しづらく、アプリ層で整合性を担保する前提


### PR DESCRIPTION
## 目的（Why）

- ER図とDDL のドキュメントを修正
- draft の申請でもコメント付与可能とする設計

## 変更内容（What）

PRに書ける粒度で、変更点だけまとめます。

* **DRAFT用テーブルを追加**

  * `draft_purchasing_approvals` を新規追加（未提出下書き用）
  * 入力項目（`title/purchase_type/amount/reason`）は **NULL許容**
  * 一覧・GC想定で `last_touched_at` を追加
  * `current_status_id` / `current_event_id` を持てるようにした

* **イベントをポリモーフィック参照に変更（B案の肝）**

  * `purchasing_approval_events` を **approval専用FK**（`purchasing_approval_id`）から変更
  * `subject_type`（`approval|draft`）+ `subject_id` を導入し、**approval/draft両方に紐付け可能**にした
  * `subject_type` に `CHECK (IN ('approval','draft'))` を追加
  * 最新イベント取得用のインデックスを `(subject_type, subject_id, id DESC)` に変更

* **current_event_id のFKを両テーブルに追加**

  * `purchasing_approvals.current_event_id -> purchasing_approval_events.id` のFK（後付け）
  * `draft_purchasing_approvals.current_event_id -> purchasing_approval_events.id` のFK（後付け）

* **comments / ai_summaries は event_id 参照のまま据え置き**

  * `purchasing_approval_comments` / `purchasing_approval_ai_summaries` は変更なし（イベントが汎用化されたことで将来DRAFTにも自然に拡張可能）

* **インデックス追加**

  * `draft_purchasing_approvals` に `user_id / current_status_id / last_touched_at` のindex追加
  * `purchasing_approval_events` に `event_at` のindex追加（タイムライン用途）

* `subject_type/subject_id` はポリモーフィック参照のため **DBのFKで存在保証できない** → **アプリ層で存在チェック**する前提。


## 動作確認（How to test）

- [ ] ローカルで確認
  - コマンド:
    - backend: `cd backend && uv run ...`
    - frontend: `cd frontend && pnpm ...`
- [ ] API確認（該当する場合）:
- [ ] 画面確認（該当する場合）:

## 関連 Issue

- Closes #13 

## 影響範囲

- [ ] frontend
- [ ] backend
- [x] infra/devcontainer
- [x] docs

## チェックリスト（最低限）

- [x] CI が通る
- [x] pre-commit を実行した（または同等の lint/format を実行）
- [x] 変更点が小さく、説明可能な単位になっている
- [x] （必要なら）ドキュメント更新

## 補足

-
