### PR TITLE
Feat/#36 show approval page create pagenation

### DIFF
--- a/backend/src/features/purchasing_approvals/list/endpoint.py
+++ b/backend/src/features/purchasing_approvals/list/endpoint.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from wireup import Injected
 
-from src.features.purchasing_approvals.list.schemas import ApprovalListResponse
+from src.features.purchasing_approvals.list.schemas import ApprovalListQueryParams, ApprovalListResponse
 from src.features.purchasing_approvals.list.service import PurchasingApprovalListService
 
 router = APIRouter(tags=["approvals", "list"])
 
 
 @router.get("/approvals", response_model=ApprovalListResponse)
-def get_approval_list(service: Injected[PurchasingApprovalListService]) -> ApprovalListResponse:
-    print("エンドポイント到達確認")
+def get_approval_list(
+    service: Injected[PurchasingApprovalListService], params: ApprovalListQueryParams = Depends()
+) -> ApprovalListResponse:
 
-    return service.execute()
+    return service.execute(query_params=params)

--- a/backend/src/features/purchasing_approvals/list/endpoint.py
+++ b/backend/src/features/purchasing_approvals/list/endpoint.py
@@ -12,4 +12,7 @@ def get_approval_list(
     service: Injected[PurchasingApprovalListService], params: ApprovalListQueryParams = Depends()
 ) -> ApprovalListResponse:
 
+    print(f"params.page: {type(params.page)}")
+    print(f"params.per_page: {type(params.per_page)}")
+
     return service.execute(query_params=params)

--- a/backend/src/features/purchasing_approvals/list/interfaces.py
+++ b/backend/src/features/purchasing_approvals/list/interfaces.py
@@ -7,5 +7,9 @@ class IApprovalListRepository(ABC):
     """申請一覧取得インターフェース"""
 
     @abstractmethod
-    def get_approval_list(self) -> list[PurchasingApproval]:
+    def get_approval_list(self, offset: int, limit: int) -> list[PurchasingApproval]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def approval_list_count_all(self) -> int:
         raise NotImplementedError

--- a/backend/src/features/purchasing_approvals/list/repository.py
+++ b/backend/src/features/purchasing_approvals/list/repository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload
 from wireup import injectable
 
@@ -13,10 +13,18 @@ class ApprovalListRepository(IApprovalListRepository):
     def __init__(self, db: Session) -> None:
         self.db = db
 
-    def get_approval_list(self) -> list[PurchasingApproval]:
+    def get_approval_list(self, offset, limit) -> list[PurchasingApproval]:
         stmt = (
             select(PurchasingApproval)
             .options(joinedload(PurchasingApproval.user), joinedload(PurchasingApproval.current_status))
-            .order_by(PurchasingApproval.created_at.desc())
+            .order_by(PurchasingApproval.created_at.desc(), PurchasingApproval.id.desc())
+            .offset(offset)
+            .limit(limit)
         )
-        return list(self.db.scalars(stmt).all())
+        result = self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    def approval_list_count_all(self) -> int:
+        stmt = select(func.count()).select_from(PurchasingApproval)
+        result = self.db.execute(stmt)
+        return result.scalar_one()

--- a/backend/src/features/purchasing_approvals/list/schemas.py
+++ b/backend/src/features/purchasing_approvals/list/schemas.py
@@ -22,8 +22,8 @@ class PaginationResponse(BaseModel):
 
     page: int = Field(..., ge=1)
     per_page: int = Field(..., ge=1)
-    total: int = Field(..., ge=1)
-    total_pages: int = Field(..., ge=1)
+    total: int = Field(..., ge=0)
+    total_pages: int = Field(..., ge=0)
     has_prev: bool
     has_next: bool
 

--- a/backend/src/features/purchasing_approvals/list/schemas.py
+++ b/backend/src/features/purchasing_approvals/list/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ApprovalListItemResponse(BaseModel):
@@ -17,8 +17,27 @@ class ApprovalListItemResponse(BaseModel):
     approved_at: datetime | None
 
 
+class PaginationResponse(BaseModel):
+    """申請リストのページネーションレスポンスモデル"""
+
+    page: int = Field(..., ge=1)
+    per_page: int = Field(..., ge=1)
+    total: int = Field(..., ge=1)
+    total_pages: int = Field(..., ge=1)
+    has_prev: bool
+    has_next: bool
+
+
+class ApprovalListQueryParams(BaseModel):
+    """申請一覧ページでリクエストされるpaginationのクエリパラメータモデル"""
+
+    page: int = Field(default=1, ge=1, description="現在ページ")
+    per_page: int = Field(default=10, ge=1, le=100, description="1ページあたりの件数")
+
+
 class ApprovalListResponse(BaseModel):
     """申請リストのレスポンスモデル"""
 
     # model_config = ConfigDict(from_attributes=True)
     items: list[ApprovalListItemResponse]
+    pagination: PaginationResponse

--- a/backend/src/features/purchasing_approvals/list/service.py
+++ b/backend/src/features/purchasing_approvals/list/service.py
@@ -1,7 +1,14 @@
+import math
+
 from wireup import injectable
 
 from src.features.purchasing_approvals.list.interfaces import IApprovalListRepository
-from src.features.purchasing_approvals.list.schemas import ApprovalListItemResponse, ApprovalListResponse
+from src.features.purchasing_approvals.list.schemas import (
+    ApprovalListItemResponse,
+    ApprovalListQueryParams,
+    ApprovalListResponse,
+    PaginationResponse,
+)
 from src.models.purchasing_approval import PurchasingApproval
 
 
@@ -12,14 +19,21 @@ class PurchasingApprovalListService:
     def __init__(self, repository: IApprovalListRepository) -> None:
         self.repository = repository
 
-    def execute(self) -> ApprovalListResponse:
-        approvals = self.repository.get_approval_list()
+    def execute(self, query_params: ApprovalListQueryParams) -> ApprovalListResponse:
+
+        offset = (query_params.page - 1) * query_params.per_page
+
+        approvals = self.repository.get_approval_list(offset=offset, limit=query_params.per_page)
+        approvals_total = self.repository.approval_list_count_all()
+
+        total_pages = math.ceil(approvals_total / query_params.per_page) if approvals_total > 0 else 0
 
         items = [self._to_item_response(approval) for approval in approvals]
 
-        return ApprovalListResponse(items=items)
+        return self._add_pagination_response(items, query_params, approvals_total, total_pages)
 
     def _to_item_response(self, approval: PurchasingApproval) -> ApprovalListItemResponse:
+        """申請一覧を取得し、レスポンスデータとしてまとめる処理"""
         return ApprovalListItemResponse(
             id=approval.id,
             title=approval.title,
@@ -28,4 +42,20 @@ class PurchasingApprovalListService:
             requested_at=approval.requested_at,
             created_at=approval.created_at,
             approved_at=approval.approved_at,
+        )
+
+    def _add_pagination_response(
+        self, items: list[ApprovalListItemResponse], query_params: ApprovalListQueryParams, total: int, total_pages: int
+    ) -> ApprovalListResponse:
+        """ページネーション情報を追加したApprovalListResponseデータにする処理"""
+        return ApprovalListResponse(
+            items=items,
+            pagination=PaginationResponse(
+                page=query_params.page,
+                per_page=query_params.per_page,
+                total=total,
+                total_pages=total_pages,
+                has_prev=query_params.page > 1,
+                has_next=query_params.page < total_pages,
+            ),
         )

--- a/backend/src/scripts/create_pagination_test_approvals.py
+++ b/backend/src/scripts/create_pagination_test_approvals.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from src.db.session import SessionLocal
+from src.models.purchasing_approval import PurchasingApproval
+from src.models.purchasing_approval_event import PurchasingApprovalEvent
+from src.models.purchasing_approval_status import PurchasingApprovalStatus
+from src.models.user import User
+
+TITLE_PREFIX = "[pagination-seed]"
+
+
+def parse_count() -> int:
+    if len(sys.argv) < 2:
+        return 100
+
+    try:
+        count = int(sys.argv[1])
+    except ValueError as exc:
+        raise ValueError("件数は整数で指定してください。例: 100") from exc
+
+    if count <= 0:
+        raise ValueError("件数は 1 以上で指定してください。")
+
+    return count
+
+
+def find_seed_user(db: Session) -> User:
+    user = db.execute(select(User).order_by(User.id.asc()).limit(1)).scalar_one_or_none()
+
+    if user is None:
+        raise ValueError("users テーブルにユーザーデータがありません。先に users seed を投入してください。")
+
+    return user
+
+
+def find_submitted_status(db: Session) -> PurchasingApprovalStatus:
+    status = db.execute(
+        select(PurchasingApprovalStatus).where(PurchasingApprovalStatus.code == "submitted").limit(1)
+    ).scalar_one_or_none()
+
+    if status is None:
+        raise ValueError("purchasing_approval_statuses に code='submitted' のデータがありません。")
+
+    return status
+
+
+def cleanup_existing_seed_data(db: Session) -> tuple[int, int]:
+    target_approvals = (
+        db.execute(select(PurchasingApproval.id).where(PurchasingApproval.title.like(f"{TITLE_PREFIX}%")))
+        .scalars()
+        .all()
+    )
+
+    if not target_approvals:
+        return (0, 0)
+
+    target_events = (
+        db.execute(
+            select(PurchasingApprovalEvent.id).where(
+                PurchasingApprovalEvent.subject_type == "approval",
+                PurchasingApprovalEvent.subject_id.in_(target_approvals),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    db.execute(delete(PurchasingApprovalEvent).where(PurchasingApprovalEvent.id.in_(target_events)))
+
+    db.execute(delete(PurchasingApproval).where(PurchasingApproval.id.in_(target_approvals)))
+
+    return (len(target_approvals), len(target_events))
+
+
+def create_seed_approvals(db: Session, count: int) -> int:
+    user = find_seed_user(db)
+    submitted_status = find_submitted_status(db)
+
+    now = datetime.now(UTC)
+
+    for i in range(count):
+        requested_at = now - timedelta(minutes=i)
+
+        approval = PurchasingApproval(
+            user_id=user.id,
+            title=f"{TITLE_PREFIX} ページネーション確認用申請 {i + 1}",
+            purchase_type="備品購入",
+            amount=Decimal("1000") + Decimal(i * 100),
+            reason=f"ページネーション確認用のテストデータ {i + 1}",
+            current_status_id=submitted_status.id,
+            current_event_id=None,
+            requested_at=requested_at,
+            approved_at=None,
+        )
+        db.add(approval)
+        db.flush()
+
+        event = PurchasingApprovalEvent(
+            subject_type="approval",
+            subject_id=approval.id,
+            performed_by=user.id,
+            status_id=submitted_status.id,
+            action="submit",
+            comment="pagination seed data",
+            event_at=requested_at,
+        )
+        db.add(event)
+        db.flush()
+
+        approval.current_event_id = event.id
+
+    return count
+
+
+def main() -> None:
+    count = parse_count()
+    db = SessionLocal()
+
+    try:
+        deleted_approvals, deleted_events = cleanup_existing_seed_data(db)
+        created_count = create_seed_approvals(db, count)
+
+        db.commit()
+
+        print("ページネーション確認用 seed の投入が完了しました。")
+        print(f"削除した申請件数: {deleted_approvals}")
+        print(f"削除したイベント件数: {deleted_events}")
+        print(f"新規作成した申請件数: {created_count}")
+
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,8 +6,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from src.db.config import build_postgresql_database_url
-from src.db.session import make_db_session
 from src.main import app
+from src.shared.container import container
 
 engine = create_engine(
     url=build_postgresql_database_url(),
@@ -25,18 +25,25 @@ TestingSessionLocal = sessionmaker(
 
 @pytest.fixture()
 def db_session() -> Iterator[Session]:
-    with TestingSessionLocal() as session:
+    """testで利用するdb_session
+    終了時に rollback / session & connectionを終了する
+    """
+
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+
+    try:
         yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
 
 
 @pytest.fixture(autouse=True)
 def client(db_session: Session) -> Iterator[TestClient]:
-    def override_make_db_session() -> Iterator[Session]:
-        yield db_session
-
-    app.dependency_overrides[make_db_session] = override_make_db_session
-
-    with TestClient(app) as test_client:
-        yield test_client
-
-    app.dependency_overrides.clear()
+    """WireUpDIコンテナのSessionをテスト用のSessionに差し替える"""
+    with container.override.injectable(target=Session, new=db_session):
+        with TestClient(app) as test_client:
+            yield test_client

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,9 +1,15 @@
 # tests/integration/conftest.py
 
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
+from src.models.purchasing_approval import PurchasingApproval
+from src.models.purchasing_approval_event import PurchasingApprovalEvent
 from src.models.purchasing_approval_status import PurchasingApprovalStatus
 from src.models.user import User
 from src.shared.enums.approval_status_enum import ApprovalStatusCode
@@ -13,7 +19,6 @@ from src.shared.security import create_access_token
 @pytest.fixture()
 def seed_user(db_session: Session) -> User:
     user = db_session.scalar(select(User).where(User.email == "applicant@example.com"))
-    print(f"get_user_data: {user}")
 
     assert user is not None
     return user
@@ -38,3 +43,73 @@ def authenticated_client(client, access_token: str):
     client.cookies.set("access_token", access_token)
     yield client
     client.cookies.clear()
+
+
+@pytest.fixture()
+def create_approvals(db_session: Session) -> Callable[..., list[PurchasingApproval]]:
+    """申請一覧のintegrationテスト用のヘルパー
+    引数でテスト用の申請データ件数を指定してテストデータを生成する
+    """
+
+    def _create(
+        *,
+        user: User,
+        status: PurchasingApprovalStatus,
+        count: int,
+    ) -> list[PurchasingApproval]:
+        now = datetime.now(UTC)
+        approvals: list[PurchasingApproval] = []
+
+        for i in range(count):
+            requested_at = now - timedelta(minutes=i)
+
+            approval = PurchasingApproval(
+                user_id=user.id,
+                title=f"一覧確認用申請 {i + 1}",
+                purchase_type="備品購入",
+                amount=Decimal("1000") + Decimal(i),
+                reason=f"一覧確認用の理由 {i + 1}",
+                current_status_id=status.id,
+                current_event_id=None,
+                requested_at=requested_at,
+                approved_at=None,
+            )
+            db_session.add(approval)
+            db_session.flush()
+
+            event = PurchasingApprovalEvent(
+                subject_type="approval",
+                subject_id=approval.id,
+                performed_by=user.id,
+                status_id=status.id,
+                action="submit",
+                comment="integration test seed",
+                event_at=requested_at,
+            )
+            db_session.add(event)
+            db_session.flush()
+
+            approval.current_event_id = event.id
+            approvals.append(approval)
+
+        db_session.flush()
+        return approvals
+
+    return _create
+
+
+@pytest.fixture()
+def cleanup_approval_tables(db_session: Session):
+    # テスト前 cleanup
+    print("cleanup before")
+    db_session.execute(delete(PurchasingApprovalEvent))
+    db_session.execute(delete(PurchasingApproval))
+    db_session.commit()
+
+    yield
+
+    # テスト後 cleanup
+    print("cleanup after")
+    db_session.execute(delete(PurchasingApprovalEvent))
+    db_session.execute(delete(PurchasingApproval))
+    db_session.commit()

--- a/backend/tests/integration/features/approvals/confirm/test_create_approval_endpoint.py
+++ b/backend/tests/integration/features/approvals/confirm/test_create_approval_endpoint.py
@@ -7,7 +7,9 @@ from src.models.purchasing_approval import PurchasingApproval
 from src.models.purchasing_approval_event import PurchasingApprovalEvent
 
 
-def test_create_approval_success(db_session, seed_user, submitted_status, authenticated_client):
+def test_create_approval_success(
+    db_session, seed_user, submitted_status, authenticated_client, cleanup_approval_tables
+):
     """正常系: 購買申請新規登録処理の成功テスト"""
 
     payload = {

--- a/backend/tests/integration/features/approvals/list/test_list_approval_endpoint.py
+++ b/backend/tests/integration/features/approvals/list/test_list_approval_endpoint.py
@@ -16,10 +16,38 @@ def test_get_approval_list_returns_paginated_response(
     assert response.status_code == 200
 
     body = response.json()
-    assert len(body["items"]) == 10
-    assert body["pagination"]["page"] == 1
-    assert body["pagination"]["per_page"] == 10
-    assert body["pagination"]["total"] == 12
-    assert body["pagination"]["total_pages"] == 2
-    assert body["pagination"]["has_prev"] is False
-    assert body["pagination"]["has_next"] is True
+    assert body["items"][0]["approval_user"] == seed_user.name
+    assert body["items"][0]["approval_status"] == submitted_status.name
+
+    assert body["pagination"] == {
+        "page": 1,
+        "per_page": 10,
+        "total": 12,
+        "total_pages": 2,
+        "has_prev": False,
+        "has_next": True,
+    }
+
+    assert [item["title"] for item in body["items"]] == [f"一覧確認用申請 {i}" for i in range(12, 2, -1)]
+
+
+def test_get_approval_list_returns_zero_paginated_response(
+    authenticated_client,
+):
+    """正常系: 申請一覧のendpoint test(0件取得時)"""
+
+    response = authenticated_client.get("/approvals?page=1&per_page=10")
+
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["items"] == []
+
+    assert body["pagination"] == {
+        "page": 1,
+        "per_page": 10,
+        "total": 0,
+        "total_pages": 0,
+        "has_prev": False,
+        "has_next": False,
+    }

--- a/backend/tests/integration/features/approvals/list/test_list_approval_endpoint.py
+++ b/backend/tests/integration/features/approvals/list/test_list_approval_endpoint.py
@@ -1,0 +1,25 @@
+def test_get_approval_list_returns_paginated_response(
+    authenticated_client,
+    seed_user,
+    submitted_status,
+    create_approvals,
+):
+    """正常系: 申請一覧のendpoint test"""
+    create_approvals(
+        user=seed_user,
+        status=submitted_status,
+        count=12,
+    )
+
+    response = authenticated_client.get("/approvals?page=1&per_page=10")
+
+    assert response.status_code == 200
+
+    body = response.json()
+    assert len(body["items"]) == 10
+    assert body["pagination"]["page"] == 1
+    assert body["pagination"]["per_page"] == 10
+    assert body["pagination"]["total"] == 12
+    assert body["pagination"]["total_pages"] == 2
+    assert body["pagination"]["has_prev"] is False
+    assert body["pagination"]["has_next"] is True

--- a/backend/tests/integration/features/approvals/list/test_list_approval_repository.py
+++ b/backend/tests/integration/features/approvals/list/test_list_approval_repository.py
@@ -18,16 +18,12 @@ def test_find_all_returns_first_page_data(
 
     items = repository.get_approval_list(offset=0, limit=10)
     total = repository.approval_list_count_all()
-
-    print(f"items_Len: {len(items)}")
-    print(f"total: {total}")
-    print(f"items[0].title:  {items[0].title}")
-    print(f"items[1].title: {items[1].title}")
+    actual_titles = [item.title for item in items]
+    expected_titles = [f"一覧確認用申請 {i}" for i in range(12, 2, -1)]
 
     assert len(items) == 10
     assert total == 12
-    assert items[0].title == "一覧確認用申請 12"
-    assert items[1].title == "一覧確認用申請 11"
+    assert actual_titles == expected_titles
 
 
 def test_find_all_returns_second_page_data(
@@ -47,8 +43,9 @@ def test_find_all_returns_second_page_data(
 
     items = repository.get_approval_list(offset=10, limit=10)
     total = repository.approval_list_count_all()
+    actual_titles = [item.title for item in items]
+    expected_titles = [f"一覧確認用申請 {i}" for i in range(2, 0, -1)]
 
     assert len(items) == 2
     assert total == 12
-    assert items[0].title == "一覧確認用申請 2"
-    assert items[1].title == "一覧確認用申請 1"
+    assert actual_titles == expected_titles

--- a/backend/tests/integration/features/approvals/list/test_list_approval_repository.py
+++ b/backend/tests/integration/features/approvals/list/test_list_approval_repository.py
@@ -1,0 +1,54 @@
+from src.features.purchasing_approvals.list.repository import ApprovalListRepository
+
+
+def test_find_all_returns_first_page_data(
+    db_session,
+    seed_user,
+    submitted_status,
+    create_approvals,
+):
+    """正常系: 申請一覧で1ページ目のデータが正常に取得できる"""
+    create_approvals(
+        user=seed_user,
+        status=submitted_status,
+        count=12,
+    )
+
+    repository = ApprovalListRepository(db_session)
+
+    items = repository.get_approval_list(offset=0, limit=10)
+    total = repository.approval_list_count_all()
+
+    print(f"items_Len: {len(items)}")
+    print(f"total: {total}")
+    print(f"items[0].title:  {items[0].title}")
+    print(f"items[1].title: {items[1].title}")
+
+    assert len(items) == 10
+    assert total == 12
+    assert items[0].title == "一覧確認用申請 12"
+    assert items[1].title == "一覧確認用申請 11"
+
+
+def test_find_all_returns_second_page_data(
+    db_session,
+    seed_user,
+    submitted_status,
+    create_approvals,
+):
+    """正常系: 申請一覧で2ページ目のデータが正常に取得できる"""
+    create_approvals(
+        user=seed_user,
+        status=submitted_status,
+        count=12,
+    )
+
+    repository = ApprovalListRepository(db_session)
+
+    items = repository.get_approval_list(offset=10, limit=10)
+    total = repository.approval_list_count_all()
+
+    assert len(items) == 2
+    assert total == 12
+    assert items[0].title == "一覧確認用申請 2"
+    assert items[1].title == "一覧確認用申請 1"

--- a/backend/tests/unit/features/approvals/list/test_approval_list_service.py
+++ b/backend/tests/unit/features/approvals/list/test_approval_list_service.py
@@ -1,0 +1,109 @@
+import math
+from datetime import UTC, datetime
+
+from src.features.purchasing_approvals.list.interfaces import IApprovalListRepository
+from src.features.purchasing_approvals.list.schemas import ApprovalListQueryParams
+from src.features.purchasing_approvals.list.service import PurchasingApprovalListService
+
+
+class StubUser:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class StubStatus:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class StubApproval:
+    def __init__(
+        self,
+        *,
+        id: int,
+        title: str,
+        approval_user: str,
+        approval_status: str,
+        requested_at: datetime | None,
+        created_at: datetime,
+        approved_at: datetime | None,
+    ) -> None:
+        self.id = id
+        self.title = title
+        self.user = StubUser(approval_user)
+        self.current_status = StubStatus(approval_status)
+        self.requested_at = requested_at
+        self.created_at = created_at
+        self.approved_at = approved_at
+
+
+class StubApprovalListRepository(IApprovalListRepository):
+    def __init__(self) -> None:
+        self.find_all_args: tuple[int, int] | None = None
+
+    def get_approval_list(self, offset: int, limit: int):
+        self.find_all_args = (offset, limit)
+        now = datetime.now(UTC)
+        return [
+            StubApproval(
+                id=1,
+                title="申請A",
+                approval_user="山田 太郎",
+                approval_status="申請中",
+                requested_at=now,
+                created_at=now,
+                approved_at=None,
+            ),
+            StubApproval(
+                id=2,
+                title="申請B",
+                approval_user="佐藤 花子",
+                approval_status="承認済み",
+                requested_at=now,
+                created_at=now,
+                approved_at=now,
+            ),
+        ]
+
+    def approval_list_count_all(self) -> int:
+        return 12
+
+
+def test_execute_returns_paginated_response() -> None:
+    """正常系: 申請一覧を取得するServiceクラス処理"""
+    repository = StubApprovalListRepository()
+    service = PurchasingApprovalListService(repository)
+
+    params = ApprovalListQueryParams(page=1, per_page=10)
+    result = service.execute(query_params=params)
+
+    print(f"repository.find_all_args: {repository.find_all_args}")
+
+    assert repository.find_all_args == (0, 10)
+
+    assert len(result.items) == 2
+    assert result.items[0].title == "申請A"
+    assert result.items[0].approval_user == "山田 太郎"
+    assert result.items[0].approval_status == "申請中"
+
+    assert result.pagination.page == 1
+    assert result.pagination.per_page == 10
+    assert result.pagination.total == 12
+    assert result.pagination.total_pages == math.ceil(12 / 10)
+    assert result.pagination.has_prev is False
+    assert result.pagination.has_next is True
+
+
+def test_execute_second_page_returns_correct_pagination() -> None:
+    """正常系: pagination２ページ目の正常取得処理"""
+
+    repository = StubApprovalListRepository()
+    service = PurchasingApprovalListService(repository)
+
+    params = ApprovalListQueryParams(page=2, per_page=10)
+    result = service.execute(query_params=params)
+
+    assert repository.find_all_args == (10, 10)
+    assert result.pagination.page == 2
+    assert result.pagination.has_prev is True
+    assert result.pagination.has_next is False

--- a/backend/tests/unit/features/approvals/list/test_approval_list_service.py
+++ b/backend/tests/unit/features/approvals/list/test_approval_list_service.py
@@ -77,8 +77,6 @@ def test_execute_returns_paginated_response() -> None:
     params = ApprovalListQueryParams(page=1, per_page=10)
     result = service.execute(query_params=params)
 
-    print(f"repository.find_all_args: {repository.find_all_args}")
-
     assert repository.find_all_args == (0, 10)
 
     assert len(result.items) == 2

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,6 +12,10 @@
 
   /* 生成り寄り（紙） */
   --color-paper: oklch(0.98 0.01 95);
+
+  /* 暫定的に定義した accent */
+  --color-accent: oklch(0.97 0.01 145);
+  --color-accent-foreground: oklch(0.25 0.02 145);
 }
 
 /* =========================
@@ -78,6 +82,16 @@
   .ui-btn--danger {
     @apply bg-red-600 text-white hover:bg-red-700
            focus:ring-red-500;
+  }
+
+  .ui-btn--ghost {
+    @apply hover:bg-accent hover:text-accent-foreground;
+  }
+
+  .ui-btn--outline {
+    @apply border border-brand-600/30 bg-white text-brand-800
+         hover:bg-accent hover:text-brand-800
+         focus:ring-brand-600;
   }
 
   .ui-btn--sm {

--- a/frontend/src/features/list/api/get-approvals.ts
+++ b/frontend/src/features/list/api/get-approvals.ts
@@ -1,8 +1,16 @@
 import { apiClient } from '@/shared/api/client';
-import { ApprovalListResponseTypes } from '../schemas/approvals-list-response-schema';
+import { ApprovalListRequestQueryTypes, ApprovalListResponseTypes } from '../schemas/approvals-list-response-schema';
 
-export const getApprovals = async (): Promise<ApprovalListResponseTypes> => {
-  return apiClient(`/approvals`, {
+export const getApprovals = async ({
+  page,
+  per_page,
+}: ApprovalListRequestQueryTypes): Promise<ApprovalListResponseTypes> => {
+  const searchParams = new URLSearchParams({
+    page: String(page),
+    per_page: String(per_page),
+  });
+
+  return apiClient(`/approvals?${searchParams.toString()}`, {
     method: 'GET',
     credentials: 'include',
     cache: 'no-store',

--- a/frontend/src/features/list/components/pagination.tsx
+++ b/frontend/src/features/list/components/pagination.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/ui';
+
+type PaginationProps = {
+  page: number;
+  totalPages: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  total?: number;
+};
+
+export function Pagination({ page, totalPages, hasPrev, hasNext, onPrev, onNext, total }: PaginationProps) {
+  return (
+    <div className="mt-4 flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-sm text-muted-foreground">
+        {typeof total === 'number' ? (
+          <span>
+            全{total}件 / {page}ページ目
+          </span>
+        ) : (
+          <span>{page}ページ目</span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onPrev} disabled={!hasPrev}>
+          前へ
+        </Button>
+
+        <span className="min-w-20 text-center text-sm text-foreground">
+          {totalPages > 0 ? `${page} / ${totalPages}` : '0 / 0'}
+        </span>
+
+        <Button type="button" variant="outline" onClick={onNext} disabled={!hasNext}>
+          次へ
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/list/hooks/use-approvals-query.test.tsx
+++ b/frontend/src/features/list/hooks/use-approvals-query.test.tsx
@@ -1,0 +1,91 @@
+import { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useApprovalsQuery } from './use-approvals-query';
+import { getApprovals } from '../api/get-approvals';
+
+vi.mock('../api/get-approvals', () => {
+  return {
+    getApprovals: vi.fn(),
+  };
+});
+
+describe('useApprovalsQuery', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    function TestQueryClientProvider({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+
+    return TestQueryClientProvider;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('page / per_page を渡して一覧データを取得できる', async () => {
+    const apiMock = vi.mocked(getApprovals);
+    apiMock.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          title: 'テスト申請',
+          approval_user: '山田 太郎',
+          approval_status: '申請中',
+          requested_at: '2026-04-09T10:00:00Z',
+          created_at: '2026-04-09T10:00:00Z',
+          approved_at: null,
+        },
+      ],
+      pagination: {
+        page: 1,
+        per_page: 10,
+        total: 1,
+        total_pages: 1,
+        has_prev: false,
+        has_next: false,
+      },
+    });
+
+    const { result } = renderHook(() => useApprovalsQuery({ page: 1, per_page: 10 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getApprovals).toHaveBeenCalledWith({ page: 1, per_page: 10 });
+    expect(result.current.data).toEqual({
+      items: [
+        {
+          id: 1,
+          title: 'テスト申請',
+          approval_user: '山田 太郎',
+          approval_status: '申請中',
+          requested_at: '2026-04-09T10:00:00Z',
+          created_at: '2026-04-09T10:00:00Z',
+          approved_at: null,
+        },
+      ],
+      pagination: {
+        page: 1,
+        per_page: 10,
+        total: 1,
+        total_pages: 1,
+        has_prev: false,
+        has_next: false,
+      },
+    });
+  });
+});

--- a/frontend/src/features/list/hooks/use-approvals-query.ts
+++ b/frontend/src/features/list/hooks/use-approvals-query.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getApprovals } from '../api/get-approvals';
-import { ApprovalListResponseTypes } from '../schemas/approvals-list-response-schema';
+import { ApprovalListRequestQueryTypes, ApprovalListResponseTypes } from '../schemas/approvals-list-response-schema';
 
-export function useApprovalsQuery() {
+export function useApprovalsQuery({ page, per_page }: ApprovalListRequestQueryTypes) {
   return useQuery<ApprovalListResponseTypes>({
-    queryKey: ['get', 'approvals'],
-    queryFn: () => getApprovals(),
+    queryKey: ['get', 'approvals', page, per_page],
+    queryFn: () => getApprovals({ page, per_page }),
     retry: false,
   });
 }

--- a/frontend/src/features/list/list.tsx
+++ b/frontend/src/features/list/list.tsx
@@ -7,11 +7,17 @@ import { PageLoading } from '@/shared/components/page-loading';
 import { ApprovalListItemTypes } from './schemas/approvals-list-response-schema';
 import { formatJapaneseDateTime } from '@/shared/formatter/format-datetime';
 import { ApprovalListEmpty } from './components/list-empty';
+import { useState } from 'react';
+import { Pagination } from './components/pagination';
 
 export function List() {
-  const { data, error, isError, isPending } = useApprovalsQuery();
+  const [page, setPage] = useState(1);
+  const [per_page] = useState(10);
+
+  const { data, error, isError, isPending } = useApprovalsQuery({ page, per_page });
 
   const items = data?.items;
+  const pagination = data?.pagination;
 
   if (isPending) return <PageLoading message="データ取得中..." />;
 
@@ -26,40 +32,51 @@ export function List() {
   if (!items || items.length === 0) return <ApprovalListEmpty />;
 
   return (
-    <Table className="min-w-295">
-      <TableHeader>
-        <TableRow className="">
-          <TableHead className="w-auto text-center">申請番号</TableHead>
-          <TableHead className="min-w-auto text-center">件名</TableHead>
-          <TableHead className="w-auto text-center">申請者</TableHead>
-          <TableHead className="w-auto text-center">ステータス</TableHead>
-          <TableHead className="w-auto text-center whitespace-nowrap">申請日時</TableHead>
-          <TableHead className="w-auto text-center whitespace-nowrap">作成日時</TableHead>
-          <TableHead className="w-auto text-center whitespace-nowrap">承認日時</TableHead>
-        </TableRow>
-      </TableHeader>
-
-      <TableBody>
-        {items?.map((item: ApprovalListItemTypes) => (
-          <TableRow key={item.id}>
-            <TableCell className="text-center">
-              <Link
-                key={item.id}
-                href={`/approvals/:${item.id}`}
-                className="font-medium text-blue-600 underline-offset-2 hover:underline hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                {item.id}
-              </Link>
-            </TableCell>
-            <TableCell className="text-center">{item.title}</TableCell>
-            <TableCell className="text-center">{item.approval_user}</TableCell>
-            <TableCell className="text-center">{item.approval_status}</TableCell>
-            <TableCell className="text-center">{formatJapaneseDateTime(item.requested_at ?? null)}</TableCell>
-            <TableCell className="text-center">{formatJapaneseDateTime(item.created_at)}</TableCell>
-            <TableCell className="text-center">{formatJapaneseDateTime(item.approved_at ?? null)}</TableCell>
+    <>
+      <Table className="min-w-295">
+        <TableHeader>
+          <TableRow className="">
+            <TableHead className="w-auto text-center">申請番号</TableHead>
+            <TableHead className="min-w-auto text-center">件名</TableHead>
+            <TableHead className="w-auto text-center">申請者</TableHead>
+            <TableHead className="w-auto text-center">ステータス</TableHead>
+            <TableHead className="w-auto text-center whitespace-nowrap">申請日時</TableHead>
+            <TableHead className="w-auto text-center whitespace-nowrap">作成日時</TableHead>
+            <TableHead className="w-auto text-center whitespace-nowrap">承認日時</TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+
+        <TableBody>
+          {items?.map((item: ApprovalListItemTypes) => (
+            <TableRow key={item.id}>
+              <TableCell className="text-center">
+                <Link
+                  key={item.id}
+                  href={`/approvals/:${item.id}`}
+                  className="font-medium text-blue-600 underline-offset-2 hover:underline hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                >
+                  {item.id}
+                </Link>
+              </TableCell>
+              <TableCell className="text-center">{item.title}</TableCell>
+              <TableCell className="text-center">{item.approval_user}</TableCell>
+              <TableCell className="text-center">{item.approval_status}</TableCell>
+              <TableCell className="text-center">{formatJapaneseDateTime(item.requested_at ?? null)}</TableCell>
+              <TableCell className="text-center">{formatJapaneseDateTime(item.created_at)}</TableCell>
+              <TableCell className="text-center">{formatJapaneseDateTime(item.approved_at ?? null)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Pagination
+        page={pagination?.page ?? 0}
+        totalPages={pagination?.total_pages ?? 0}
+        hasPrev={pagination?.has_prev ?? false}
+        hasNext={pagination?.has_next ?? false}
+        onPrev={() => console.log('click on prev')}
+        onNext={() => console.log('click on next')}
+        total={pagination?.total ?? 0}
+      />
+    </>
   );
 }

--- a/frontend/src/features/list/list.tsx
+++ b/frontend/src/features/list/list.tsx
@@ -19,6 +19,15 @@ export function List() {
   const items = data?.items;
   const pagination = data?.pagination;
 
+  const handlePrevPage = () => {
+    setPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  const handleNextPage = () => {
+    if (!data?.pagination.has_next) return;
+    setPage((prev) => prev + 1);
+  };
+
   if (isPending) return <PageLoading message="データ取得中..." />;
 
   if (isError)
@@ -73,8 +82,8 @@ export function List() {
         totalPages={pagination?.total_pages ?? 0}
         hasPrev={pagination?.has_prev ?? false}
         hasNext={pagination?.has_next ?? false}
-        onPrev={() => console.log('click on prev')}
-        onNext={() => console.log('click on next')}
+        onPrev={handlePrevPage}
+        onNext={handleNextPage}
         total={pagination?.total ?? 0}
       />
     </>

--- a/frontend/src/features/list/schemas/approvals-list-response-schema.ts
+++ b/frontend/src/features/list/schemas/approvals-list-response-schema.ts
@@ -5,14 +5,30 @@ export const ApprovalListItemSchema = z.object({
   title: z.string(),
   approval_user: z.string(),
   approval_status: z.string(),
-  requested_at: z.string().optional(),
+  requested_at: z.string().nullable(),
   created_at: z.string(),
-  approved_at: z.string().optional(),
+  approved_at: z.string().nullable(),
+});
+
+export const ApprovalListPaginationSchema = z.object({
+  page: z.number(),
+  per_page: z.number(),
+  total: z.number(),
+  total_pages: z.number(),
+  has_prev: z.boolean(),
+  has_next: z.boolean(),
+});
+
+export const ApprovalListRequestQuerySchema = z.object({
+  page: z.number(),
+  per_page: z.number(),
 });
 
 export const ApprovalListResponseSchema = z.object({
   items: z.array(ApprovalListItemSchema),
+  pagination: ApprovalListPaginationSchema,
 });
 
 export type ApprovalListItemTypes = z.infer<typeof ApprovalListItemSchema>;
 export type ApprovalListResponseTypes = z.infer<typeof ApprovalListResponseSchema>;
+export type ApprovalListRequestQueryTypes = z.infer<typeof ApprovalListRequestQuerySchema>;

--- a/frontend/src/shared/components/button-loading-content.test.tsx
+++ b/frontend/src/shared/components/button-loading-content.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ButtonLoadingContent } from './button-loading-content';
+
+vi.mock('@/ui/spinner', () => {
+  return {
+    Spinner: ({ size, label }: { size: string; label: string }) => (
+      <div data-testid="spinner" data-size={size} aria-label={label} />
+    ),
+  };
+});
+
+describe('ButtonLoadingContent', () => {
+  it('デフォルト表示を描画する', () => {
+    render(<ButtonLoadingContent />);
+
+    expect(screen.getByText('送信中...')).toBeInTheDocument();
+
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner).toHaveAttribute('data-size', 'sm');
+    expect(spinner).toHaveAttribute('aria-label', 'button-loading');
+  });
+
+  it('text を差し替えられる', () => {
+    render(<ButtonLoadingContent text="保存中..." />);
+
+    expect(screen.getByText('保存中...')).toBeInTheDocument();
+  });
+
+  it('spinnerSize を Spinner に渡せる', () => {
+    render(<ButtonLoadingContent spinnerSize="lg" />);
+
+    expect(screen.getByTestId('spinner')).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('className を付与できる', () => {
+    render(<ButtonLoadingContent className="test-class" />);
+
+    expect(screen.getByText('送信中...').parentElement).toHaveClass('test-class');
+  });
+});

--- a/frontend/src/shared/components/global-loading-overlay.test.tsx
+++ b/frontend/src/shared/components/global-loading-overlay.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GlobalLoadingOverlay } from './global-loading-overlay';
+
+vi.mock('@/ui/overlay', () => {
+  return {
+    Overlay: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+      <div data-testid="overlay" data-open={String(open)}>
+        {children}
+      </div>
+    ),
+  };
+});
+
+vi.mock('@/ui/spinner', () => {
+  return {
+    Spinner: ({ size, label }: { size: string; label: string }) => (
+      <div data-testid="spinner" data-size={size} aria-label={label} />
+    ),
+  };
+});
+
+describe('GlobalLoadingOverlay', () => {
+  it('デフォルト値で描画できる', () => {
+    render(<GlobalLoadingOverlay />);
+
+    const overlay = screen.getByTestId('overlay');
+    expect(overlay).toHaveAttribute('data-open', 'false');
+
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-busy', 'false');
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner).toHaveAttribute('data-size', 'md');
+    expect(spinner).toHaveAttribute('aria-label', 'global-loading');
+  });
+
+  it('open=true を Overlay と aria-busy に反映する', () => {
+    render(<GlobalLoadingOverlay open />);
+
+    expect(screen.getByTestId('overlay')).toHaveAttribute('data-open', 'true');
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('message と spinnerSize を反映できる', () => {
+    render(<GlobalLoadingOverlay open message="保存中です..." spinnerSize="lg" />);
+
+    expect(screen.getByText('保存中です...')).toBeInTheDocument();
+    expect(screen.getByTestId('spinner')).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('className を付与できる', () => {
+    render(<GlobalLoadingOverlay className="test-class" />);
+
+    expect(screen.getByRole('status')).toHaveClass('test-class');
+  });
+});

--- a/frontend/src/shared/components/page-loading.test.tsx
+++ b/frontend/src/shared/components/page-loading.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PageLoading } from './page-loading';
+
+vi.mock('@/ui/spinner', () => {
+  return {
+    Spinner: ({ size, label }: { size: string; label: string }) => (
+      <div data-testid="spinner" data-size={size} aria-label={label} />
+    ),
+  };
+});
+
+describe('PageLoading', () => {
+  it('デフォルトのローディング表示を描画する', () => {
+    render(<PageLoading />);
+
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner).toHaveAttribute('data-size', 'lg');
+    expect(spinner).toHaveAttribute('aria-label', 'page-loading');
+  });
+
+  it('message prop で表示文言を差し替えられる', () => {
+    render(<PageLoading message="申請一覧を取得中です..." />);
+
+    expect(screen.getByText('申請一覧を取得中です...')).toBeInTheDocument();
+  });
+
+  it('spinnerSize prop を Spinner に渡す', () => {
+    render(<PageLoading spinnerSize="sm" />);
+
+    expect(screen.getByTestId('spinner')).toHaveAttribute('data-size', 'sm');
+  });
+
+  it('className を付与できる', () => {
+    render(<PageLoading className="test-class" />);
+
+    expect(screen.getByRole('status')).toHaveClass('test-class');
+  });
+});

--- a/frontend/src/shared/formatter/format-datetime.test.ts
+++ b/frontend/src/shared/formatter/format-datetime.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { formatJapaneseDateTime } from './format-datetime';
+
+describe(`formatJapaneseDateTime`, () => {
+  it(`valueがnullの場合 - を返す`, () => {
+    expect(formatJapaneseDateTime(null)).toBe('-');
+  });
+
+  it(`valueが日付の文字列の場合 日本の時刻表示形式を返す`, () => {
+    const testDateValue = new Date('1993-03-30T12:59:59Z').toString();
+
+    expect(formatJapaneseDateTime(testDateValue)).toBe(`1993年/3月/30日 12時59分59秒`);
+  });
+});

--- a/frontend/src/ui/button/button.tsx
+++ b/frontend/src/ui/button/button.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/shared/cn';
 import { ComponentPropsWithoutRef } from 'react';
 
 type ButtonProps = ComponentPropsWithoutRef<'button'> & {
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline';
   size?: 'sm' | 'md';
   isLoading?: boolean;
 };
@@ -25,6 +25,8 @@ export function Button({
         variant === 'primary' && 'ui-btn--primary',
         variant === 'secondary' && 'ui-btn--secondary',
         variant === 'danger' && 'ui-btn--danger',
+        variant === 'ghost' && 'ui-btn--ghost',
+        variant === 'outline' && 'ui-btn--outline',
         size === 'sm' && 'ui-btn--sm',
         size === 'md' && 'ui-btn--md',
         className,


### PR DESCRIPTION
## 目的（Why）

- 申請一覧画面にページネーション機能を追加する
- 申請データ件数が増えた場合でも、一覧画面を見やすく保ち、操作性を向上させる
- 一覧取得APIのレスポンスをページ単位で取得できるようにし、今後の検索 / 絞り込み機能追加の土台にする

## 変更内容（What）

- 申請一覧取得APIを page / per_page の query parameter に変更
- レスポンスを items と pagination を含む形式へ変更
- pagination には以下を含める
  - page
  - per_page
  - total
  - total_pages
  - has_prev
  - has_next
- 申請データが0件の場合でも 500 ではなく、正常に空配列と0件用 pagination を返す

## 動作確認（How to test）

- [x] ローカルで確認
  - コマンド:
    - backend: `cd backend && uv run pytest -vv`
    - frontend: `cd frontend && pnpm test`
- [ ] API確認（該当する場合）:
- [ ] 画面確認（該当する場合）:

## 関連 Issue

- Closes #36 

## 影響範囲

- [x] frontend
- [x] backend
- [ ] infra/devcontainer
- [ ] docs

## チェックリスト（最低限）

- [x] CI が通る
- [x] pre-commit を実行した（または同等の lint/format を実行）
- [ ] 変更点が小さく、説明可能な単位になっている
- [ ] （必要なら）ドキュメント更新

## 補足

- backendの `tests/conftest.py`で定義した db_session と clientを以下の内容に変更
  - db_session -> rollbackするように処理内容を修正
  - client -> 今回 WireUpでDI管理しているため、WireUpのcontainerで管理しているSessionを差し替える内容に修正
